### PR TITLE
'屏蔽SDK请求日志记录，避免大量相同日志堆积'

### DIFF
--- a/src/qcloud/CMQ/CMQHttp.php
+++ b/src/qcloud/CMQ/CMQHttp.php
@@ -68,7 +68,7 @@ class CMQHttp
         if (isset($req_inter->header)) {
             curl_setopt($this->curl, CURLOPT_HTTPHEADER, $req_inter->header);
         }
-        Log::info($url);
+        // Log::info($url);
         curl_setopt($this->curl, CURLOPT_URL, $url);
         curl_setopt($this->curl, CURLOPT_TIMEOUT, $this->connection_timeout +$userTimeout );
 


### PR DESCRIPTION
首先感谢该sdk的方便性，另外在使用过程中，偶然发现laravel日志量增加太多，经过排查发现全都是CMQ的sdk记录所致，而且所有日志都是相同的请求url信息，这个记录信息其实是没有意义的，可能是临时测试的一个断点标记吧，移除掉应该更合适。

该日志记录一般应该在业务控制器和轮询过程中结合队列执行参数进行单独记录，希望能采纳，谢谢。


[2022-07-03 14:47:08] local.INFO: https://cmq-cd.public.tencenttdmq.com/v2/index.php  
[2022-07-03 14:47:14] local.INFO: https://cmq-cd.public.tencenttdmq.com/v2/index.php  